### PR TITLE
Changes to topf calculation

### DIFF
--- a/scrollYou.js
+++ b/scrollYou.js
@@ -36,7 +36,7 @@
 
         scrollListener: function() {
             var that = this;
-            var acell = this.options.acell || 3,
+            var acell = this.options.acell || 100,
                 height = this.getHeight();
 
             this.$element.on('mousewheel', $.proxy(function(event, delta, deltaX, deltaY) {
@@ -46,7 +46,8 @@
                 event.currentTarget.scrollTop -= (delta * acell);
 
                 topf = event.currentTarget.scrollTop + this.initialTop +
-                       event.currentTarget.scrollTop * (this.getElementHeight()) / height;
+                       event.currentTarget.scrollTop * (this.getElementHeight() - this.$scroll.height() - 2 * this.initialTop) / 
+                       (this.$element.prop('scrollHeight') - this.getElementHeight());
 
                 this.$scroll.css({
                     'top': topf

--- a/scrollyou.css
+++ b/scrollyou.css
@@ -1,5 +1,4 @@
 .scrollyou {
-    height: 100px;
     overflow: hidden !important;
     position: relative;
 }


### PR DESCRIPTION
I made some changes to the way topf is calculated to ensure that the scrollbar always reaches the bottom at the correct spot. I also upped the default acell value to 100, as I found 3 to be too slow, and not at all what I'm used to with my default scrollbar. Also removed the height set on the .scrollYou class. You can see an example of it in action here: http://jsfiddle.net/caseyjhol/LQnky/5/ using the red box on the left. The red box on the right is for comparison to normal select functionality.
